### PR TITLE
[BUGFIX] Docker fixed "cgo: C compiler "gcc" not found: exec: "gcc": …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,18 @@
 FROM golang:1.18.3-alpine3.16 as base
+
+ENV CGO_ENABLED 0
+RUN apk add --update --no-cache make
+
 ENV WORKDIR=/app
 WORKDIR ${WORKDIR}
 
 FROM base as development
 
 FROM development as builder
-RUN apk add --update --no-cache make
 
 COPY ./src ${WORKDIR}/src
 COPY ./go.mod ${WORKDIR}/
+COPY ./go.sum ${WORKDIR}/
 COPY ./Makefile ${WORKDIR}/
 
 RUN make dependencies


### PR DESCRIPTION
…executable file not found in $PATH":

https://stackoverflow.com/questions/43580131/exec-gcc-executable-file-not-found-in-path-when-trying-go-build