### PR TITLE
New way to pass ENVIRONMENT VARIABLES to runtime, to control DEBUG ou…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,16 @@ RUN make dependencies
 
 FROM builder as testing
 
+ENV LOG_LEVEL=INFO
+ENV BRUTEFORCE=FALSE
+
+RUN adduser -D worker
+RUN mkdir -p /app
+RUN chown worker:worker /app
+
 WORKDIR /app
 
 RUN ls -alh
 
-CMD ["make", "all"]
+USER worker
+CMD ["make", "test"]

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,68 @@
+## REFERENCES:
+## (1) Passing environment variable with fallback value to Makefile:
+##    https://stackoverflow.com/a/70772707/6366150
+## (2) Export environment variables inside "make environment"
+##		https://stackoverflow.com/a/49524393/6366150
+## (3) Uppercase to lowercase and vice versa
+##		https://community.unix.com/t/uppercase-to-lowercase-and-vice-versa/285278/6
+## (4) How do I trim leading and trailing whitespace from each line of some output?
+## 		https://unix.stackexchange.com/a/279222/233927
+############################################################################
+
+## (1) ## Allowed values: info | warn | error | debug
+LOG_LEVEL ?= info
+## (3) (4)
+LOG_LEVEL :=$(shell echo '${LOG_LEVEL}'| tr '[:lower:]' '[:upper:]'| tr -d '[:blank:]')
+
+## (1) ## Allowed values: true | false
+BRUTEFORCE ?= false
+## (3) (4)
+BRUTEFORCE :=$(shell echo '${BRUTEFORCE}'| tr '[:lower:]' '[:upper:]'| tr -d '[:blank:]')
+
+ifeq ($(BRUTEFORCE),1)
+  add_bruteforce=-tags bruteforce
+endif
+ifeq ($(BRUTEFORCE),TRUE)
+  add_bruteforce=-tags bruteforce
+endif
+
 GO=go
-GOTEST=$(GO) test
+GOTEST=$(GO) test $(add_bruteforce)
 GOCOVER=$(GO) tool cover
 PKG_LIST=$(go list ./... | grep -v /vendor/ | tr '\n' ' '| xargs echo -n)
 
 .MAIN: test/coverage
 .PHONY: all clean coverage dependencies help list test
+.EXPORT_ALL_VARIABLES: # (2)
 
 help: list
 
 list:
+	@echo "Environment variables:"
+	@echo "LOG_LEVEL = info | warn | error | debug"
+	@echo "BRUTEFORCE = true | false"
+	@echo ""
+	@echo "Posible make commands:"
 	@LC_ALL=C $(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$'
 
-dependencies:
-	$(GO) mod download
+env:
+	@echo "################################################################################"
+	@echo "## Environment: ################################################################"
+	@echo "################################################################################"
+	@printenv | grep -E "LOG_LEVEL|BRUTEFORCE"
+	@echo "################################################################################"
 
-coverage/c.out: dependencies
+dependencies:
+	@echo "################################################################################"
+	@echo "## Dependencies: ###############################################################"
+	@echo "################################################################################"
+	$(GO) mod download
+	@echo "################################################################################"
+
+coverage/c.out: env dependencies
 	$(GOTEST) -v -coverprofile="coverage/c.out" ./...
 
 test: coverage/c.out
-
-test/bruteforce: dependencies
-	$(GOTEST) -v -tags bruteforce -coverprofile="coverage/c.out" ./...
 
 coverage: coverage/c.out
 	$(GOCOVER) -func=coverage/c.out
@@ -31,5 +73,14 @@ clean:
 	rm -vfr ./coverage
 	mkdir -p ./coverage
 	touch ./coverage/.gitkeep
+
+docker/build:
+	BUILDKIT_PROGRESS=plain docker-compose --profile testing build
+
+docker/rebuild:
+	BUILDKIT_PROGRESS=plain docker-compose --profile testing build --no-cache
+
+docker/compose-run: docker/build
+	docker-compose --profile testing run --rm projecteuler-go make test
 
 all: test coverage

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,14 @@ ifeq ($(BRUTEFORCE),TRUE)
   add_bruteforce=-tags bruteforce
 endif
 
+# Package Manager
 GO=go
 GOTEST=$(GO) test $(add_bruteforce)
 GOCOVER=$(GO) tool cover
 PKG_LIST=$(go list ./... | grep -v /vendor/ | tr '\n' ' '| xargs echo -n)
+
+# DOCKER
+BUILDKIT_PROGRESS=plain
 
 .MAIN: test/coverage
 .PHONY: all clean coverage dependencies help list test
@@ -74,11 +78,11 @@ clean:
 	mkdir -p ./coverage
 	touch ./coverage/.gitkeep
 
-docker/build:
-	BUILDKIT_PROGRESS=plain docker-compose --profile testing build
+docker/compose-build: env
+	docker-compose --profile testing build
 
-docker/rebuild:
-	BUILDKIT_PROGRESS=plain docker-compose --profile testing build --no-cache
+docker/compose-rebuild: env
+	docker-compose --profile testing build --no-cache
 
 docker/compose-run: docker/build
 	docker-compose --profile testing run --rm projecteuler-go make test

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You must install dependencies:
 go mod download
 ```
 
-Or using make 
+Or using make
 
 ```
 make dependencies
@@ -57,10 +57,41 @@ go tool -func=coverage/c.out
 go tool -html=coverage/c.out
 ```
 
-Or using make:
+### Testing with full logs
+
+Run all tests with debug outputs:
 
 ```
-make test coverage
+LOG_LEVEL=debug go test -v -coverprofile=coverage/c.out ./...
+```
+
+Use one of following values: debug, warn, error, info.
+
+## Testing using make
+
+```
+make test
+```
+
+### Enable all large BRUTEFORCE tests
+
+Direct in host using a make:
+
+```
+make test -e BRUTEFORCE=true
+```
+
+### Enable all DEBUG outputs
+
+
+```
+make test -e LOG_LEVEL=debug
+```
+
+### Enable all large BRUTEFORCE tests and all DEBUG outputs
+
+```
+make test -e LOG_LEVEL=debug -e BRUTEFORCE=true
 ```
 
 # Running with Docker 🐳
@@ -77,6 +108,18 @@ docker-compose build projecteuler-go
 docker-compose run --rm projecteuler-go make test coverage
 ```
 
+## Enable BRUTEFORCE tests with full DEBUG output
+
+With docker-compose:
+
+```
+docker-compose --profile testing run --rm projecteuler-go make test -e LOG_LEVEL=DEBUG -e BRUTEFORCE=true
+```
+
+Using make:
+```
+make docker/compose-run -e LOG_LEVEL=DEBUG -e BRUTEFORCE=true
+```
 
 ## Build and run a development image
 
@@ -96,7 +139,7 @@ Developed with runtime:
 
 ```
 go version
-go version go1.18.3 darwin/amd64
+go version go1.19.3 darwin/amd64
 ```
 
 ## License

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,7 +5,8 @@ services:
       context: .
       target: testing
     environment:
-      _DEBUG: ${_DEBUG}
+      LOG_LEVEL: ${LOG_LEVEL:-INFO} ## (1) ## INFO | WARN | ERROR | DEBUG
+      BRUTEFORCE: ${BRUTEFORCE:-false} ## (1) ## TRUE | FALSE
     volumes:
       - ./coverage:/app/coverage
     profiles: ["testing"]
@@ -16,7 +17,8 @@ services:
       context: .
       target: development
     environment:
-      _DEBUG: ${_DEBUG}
+      LOG_LEVEL: ${LOG_LEVEL:-INFO} ## (1) ## INFO | WARN | ERROR | DEBUG
+      BRUTEFORCE: ${BRUTEFORCE:-false} ## (1) ## TRUE | FALSE
     volumes:
       - ./:/app
     profiles: ["development"]

--- a/src/problem0014.go
+++ b/src/problem0014.go
@@ -35,7 +35,7 @@ func Problem0014(bottom int, top int) int {
 	for i := bottom; i < top; i += 1 {
 
 		var sequence []int = helpers.CollatzSequence(i)
-		utils.Info("sequence of %d: %v", i, sequence)
+		utils.Debug("sequence of %d: %v", i, sequence)
 
 		if len(sequence) > len(maxSequence) {
 			maxSequence = sequence

--- a/src/utils/getEnv.go
+++ b/src/utils/getEnv.go
@@ -1,0 +1,14 @@
+package utils
+
+import (
+	"os"
+)
+
+// GetEnv get key environment variable if exist otherwise return defalutValue
+func GetEnv(key, defaultValue string) string {
+	value := os.Getenv(key)
+	if len(value) == 0 {
+		return defaultValue
+	}
+	return value
+}

--- a/src/utils/logger.go
+++ b/src/utils/logger.go
@@ -2,11 +2,13 @@ package utils
 
 import (
 	"fmt"
-	"os"
+	"strings"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
+
+const __FALLBACK_LOG_LEVEL__ = "INFO"
 
 type Log struct {
 	log *zap.Logger
@@ -16,8 +18,15 @@ type Fields map[string]string
 
 var instance *Log
 
-func getLogLevel(logLevel string) zapcore.Level {
+func getLogLevel(_logLevel string) zapcore.Level {
 	zapLogLevel := zap.DebugLevel
+
+	logLevel := _logLevel
+	logLevel = strings.ToUpper(logLevel)
+	logLevel = strings.TrimSpace(logLevel)
+
+	fmt.Printf("Search for LOG_LEVEL availability: [%s] \n", logLevel)
+
 	switch logLevel {
 	case "INFO":
 		zapLogLevel = zap.InfoLevel
@@ -28,14 +37,18 @@ func getLogLevel(logLevel string) zapcore.Level {
 	case "ERROR":
 		zapLogLevel = zap.ErrorLevel
 	default:
-		zapLogLevel = zap.DebugLevel
+		zapLogLevel = zap.InfoLevel
 	}
 	return zapLogLevel
 }
 
 func init() {
+	level := getLogLevel(GetEnv("LOG_LEVEL", __FALLBACK_LOG_LEVEL__))
+
 	log := initLoggerZap()
-	log.Info(fmt.Sprintf("Log loaded successfully with level: %s", os.Getenv("LOG_LEVEL")))
+
+	fmt.Printf("Log loaded successfully with level: [%s] \n", level.CapitalString())
+
 	instance = &Log{log: log}
 }
 
@@ -43,7 +56,7 @@ func initLoggerZap() *zap.Logger {
 	cfg := zap.Config{
 		Encoding:         "json",
 		DisableCaller:    true,
-		Level:            zap.NewAtomicLevelAt(getLogLevel(os.Getenv("LOG_LEVEL"))),
+		Level:            zap.NewAtomicLevelAt(getLogLevel(GetEnv("LOG_LEVEL", __FALLBACK_LOG_LEVEL__))),
 		OutputPaths:      []string{"stdout"},
 		ErrorOutputPaths: []string{"stdout"},
 		EncoderConfig: zapcore.EncoderConfig{


### PR DESCRIPTION
…tput and enable/disable BRUTEFORCE test, with fallback values.

REFERENCES:
 * Define a Makefile variable using a ENV variable or a default value https://stackoverflow.com/a/24263397/6366150
 * Docker compose .env default with fallback https://stackoverflow.com/a/70772707/6366150
 * Export environment variables inside "make environment" https://stackoverflow.com/a/49524393/6366150
 * Uppercase to lowercase and vice versa https://community.unix.com/t/uppercase-to-lowercase-and-vice-versa/285278/6
 * How do I trim leading and trailing whitespace from each line of some output? https://unix.stackexchange.com/a/279222/233927